### PR TITLE
Make sure window.project_data() is not None

### DIFF
--- a/remote_edit.py
+++ b/remote_edit.py
@@ -30,7 +30,7 @@ def get_settings(window=None, create_if_missing=None):
     }
 
     all_settings = [sublime.load_settings('RemoteEdit.sublime-settings')]
-    if hasattr(window, 'project_data'):
+    if hasattr(window, 'project_data') and window.project_data() is not None:
         all_settings.append(window.project_data().get('remote_edit'))
 
     for sub_settings in all_settings:


### PR DESCRIPTION
When a project isn't set up, `window.project_data()` will be `None` and python will crash attempting to call `get()` on `None`.

Fixes #10 and #4 