### PR TITLE
Support for custom ssh/scp paths and identity file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,15 @@ Create an alias, an alias points to a configuration for a specific server.
 				"address": "IPADDRESS_OR_SERVERNAME",
 				// Username to log into server with
 				// Not required, the command line scp will default it to current user
-				"username": "USERNAME_ON_REMOTE_MACHINE"
+				"username": "USERNAME_ON_REMOTE_MACHINE",
+
+				"ssh_exec_path": "OPTIONAL_CUSTOM_PATH_TO_SSH",
+				"scp_exec_path": "OPTIONAL_CUSTOM_PATH_TO_SCP",
+				"cert_path": "OPTIONAL_CUSTOM_PATH_TO_PRIVATE_KEY",
 				// NOTE: Remember, to authenticate you need to have your pub key
 				// registered in the remote server ssh's authorized_keys file.,
+				// Tweak the string for paths with spaces.
+
 				"create_if_missing": false
 			},
 		}
@@ -83,6 +89,11 @@ In your current project file, you can also add aliases:
 				{
 					"address": "IPADDRESS_OR_SERVERNAME",
 					"username": "USERNAME_ON_REMOTE_MACHINE",
+
+					"ssh_exec_path": "OPTIONAL_CUSTOM_PATH_TO_SSH",
+					"scp_exec_path": "OPTIONAL_CUSTOM_PATH_TO_SCP",
+					"cert_path": "OPTIONAL_CUSTOM_PATH_TO_PRIVATE_KEY",
+
 					"create_if_missing": false
 				}
 			}

--- a/RemoteEdit.sublime-settings
+++ b/RemoteEdit.sublime-settings
@@ -8,10 +8,20 @@
 			
 			// Username to log into server with
 			// Not required, the command line scp will default it to current user
-	//		"username": "USERNAME_ON_REMOTE_MACHINE"
+	//		"username": "USERNAME_ON_REMOTE_MACHINE",
 
-			// NOTE: Remember, to authenticate you need to have your pub key
-			// registered in the remote server ssh's authorized_keys file.
+			//  Optional; Custom path to ssh/scp binaries.
+	//		"ssh_exec_path" : "Z:\\PortableGit\\mingw64\\bin\\ssh.exe",
+	//		"scp_exec_path" : "Z:\\PortableGit\\mingw64\\bin\\scp.exe",
+
+			//  Optional; Specify private key file to be used
+	//		"cert_path": "Z:\\.ssh\\sublime_id_rsa"
+
+			// NOTE:
+			//  (1) Remember to authenticate you need to have your pub key
+			//      registered in the remote server ssh's authorized_keys file.
+			//  (2) For ssh/scp/cert paths with spaces, tweak your string accordingly.
+			//      Ex: In Windows, enclose in double quotes. In Unix, escape with '\'
 	//	},
 	}
 }

--- a/remote_edit.py
+++ b/remote_edit.py
@@ -58,7 +58,6 @@ def get_ssh_listing(ssh_exec_path, cert_path, address, path, warn=True):
     cert_opts = ('-i %s ' % cert_path) if cert_path else ''
     command = '%s %s-o StrictHostKeychecking=no "%s" ls -aF "%s"' % (ssh_exec_path, cert_opts, address, path)
     log('Command: \'%s\'' % command)
-    sublime.message_dialog(command)
     pipe = subprocess.Popen(
         command,
         stdin=subprocess.PIPE,


### PR DESCRIPTION
Added support to optionally customize the paths to ssh and scp binaries, and identity file (-i option).

Tested in Windows, not in Linux.